### PR TITLE
Merge clean interface

### DIFF
--- a/tfutils/base.py
+++ b/tfutils/base.py
@@ -497,6 +497,8 @@ def predict(step, results):
 
 def run_targets(sess, dbinterface, target_name, target, num_steps, 
                 online_agg_func, agg_func, save_intermediate_freq, validation_only):
+    """TODO:  this code resembles train() function, possible want to unify
+    """
     agg_res = None
     if save_intermediate_freq:
         n0 = len(dbinterface.outrecs)
@@ -613,7 +615,7 @@ def test_from_params(load_params,
         ld = dbinterface.load_data
         assert ld is not None, "No load data found for query, aborting"
         ld = ld[0]
-        ###TODO: reconstitute model_params entirely from saved object ("revivification")
+        ###TODO: have option to reconstitute model_params entirely from saved object ("revivification")
         model_params['cfg_initial'] = ld['params']['model_params']['cfg_initial']
         model_params['seed'] = ld['params']['model_params']['seed']
         cfg_final = ld['params']['model_params']['cfg_final']
@@ -841,6 +843,8 @@ def train_from_params(save_params,
     """
 
     with tf.Graph().as_default():  # to have multiple graphs [ex: eval, train]
+        ####TODO:  option to try to load first and see if records exist
+        ####       and if so, construct entirely from record ("revivification").  
         global_step = tf.get_variable('global_step', [],
                                       initializer=tf.constant_initializer(0),
                                       dtype=tf.int64,
@@ -951,7 +955,7 @@ def get_valid_targets_dict(validation_params,
 
 
 def check_model_equivalence(m1, m2, name):
-    """TODO: fill this in"""
+    """TODO: fill this in to make it stronger"""
     assert set(m1.keys()) == set(m2.keys()), (m1.keys(), m2.keys())
     
 def get_validation_target(vinputs, voutputs,

--- a/tfutils/base.py
+++ b/tfutils/base.py
@@ -870,12 +870,11 @@ def train_from_params(save_params,
         learning_rate_params, learning_rate = call_learning_rate(global_step, 
                                                                  **learning_rate_params)
 
-        if optimizer_params is None:
-            optimizer_params = get_default_optimizer_params()
+
         optimizer_params, optimizer = call_optimizer(learning_rate, 
                                                      loss, 
                                                      global_step, 
-                                                     **optimizer_params)
+                                                     optimizer_params)
 
         train_targets = {'loss': loss,
                          'learning_rate': learning_rate,
@@ -1026,8 +1025,10 @@ def call_learning_rate(global_step, func=tf.train.exponential_decay, **learning_
 def call_optimizer(learning_rate, 
                    loss,
                    global_step,                   
-                   func=ClipOptimizer,
-                   **optimizer_params):
+                   optimizer_params):
+    if optimizer_params is None:
+        optimizer_params = get_default_optimizer_params()
+    func = optimizer_params.pop('func', ClipOptimizer)
     optimizer_base = func(learning_rate=learning_rate,
                           **optimizer_params)
     optimizer = optimizer_base.minimize(loss, global_step)

--- a/tfutils/base.py
+++ b/tfutils/base.py
@@ -428,7 +428,7 @@ class DBInterface(object):
             save_rec = sonify(rec)
             make_mongo_safe(save_rec)
 
-            thread = threading.Thread(target=self.save_thread, 
+            thread = threading.Thread(target=self._save_thread, 
                                  args=(save_filters_permanent, save_filters_tmp, save_rec, step, save_to_gfs))
             thread.daemon = True
             thread.start()
@@ -439,7 +439,7 @@ class DBInterface(object):
             self.checkpoint_thread.join()
             self.checkpoint_thread = None
 
-    def save_thread(self, save_filters_permanent, save_filters_tmp, save_rec, step, save_to_gfs):
+    def _save_thread(self, save_filters_permanent, save_filters_tmp, save_rec, step, save_to_gfs):
         if save_filters_permanent or save_filters_tmp:
             save_rec['saved_filters'] = True
             save_path = os.path.join(self.cache_dir, 'checkpoint')
@@ -694,7 +694,7 @@ def train(sess,
     train_results = {}
     dbinterface.start_time_step = time.time()
     while step < num_steps:
-        if train_results or step == 0: _validate_and_save(train_results, step)
+        if (len(train_results) > 0) or step == 0: _validate_and_save(train_results, step)
         old_step = step
         dbinterface.start_time_step = time.time()
         train_results = sess.run(train_targets)
@@ -958,6 +958,7 @@ def check_model_equivalence(m1, m2, name):
     """TODO: fill this in to make it stronger"""
     assert set(m1.keys()) == set(m2.keys()), (m1.keys(), m2.keys())
     
+
 def get_validation_target(vinputs, voutputs,
                           default_target_func=utils.get_loss_dict,
                           default_target_params=DEFAULT_LOSS_PARAMS,

--- a/tfutils/data.py
+++ b/tfutils/data.py
@@ -219,12 +219,12 @@ class Queue(object):
                                'to Queue constructor or have it defined in '
                                'data_iter.batch_size.')
 
-        nodes = {}
+        self.nodes = {}
         dtypes = []
         shapes = []
         self._first_batch = self.data_iter.next()
         for key, value in self._first_batch.items():
-            nodes[key] = tf.placeholder(value.dtype, shape=value.shape, name=key)
+            self.nodes[key] = tf.placeholder(value.dtype, shape=value.shape, name=key)
             dtypes.append(value.dtype)
             if data_batch_size > 1:
                 shapes.append(value.shape[1:])
@@ -236,30 +236,30 @@ class Queue(object):
                                                min_after_dequeue=self.capacity // 2,
                                                dtypes=dtypes,
                                                shapes=shapes,
-                                               names=nodes.keys(),
+                                               names=self.nodes.keys(),
                                                seed=seed)
         elif queue_type == 'fifo':
             self.queue = tf.FIFOQueue(capacity=self.capacity,
                                       dtypes=dtypes,
                                       shapes=shapes,
-                                      names=nodes.keys())
+                                      names=self.nodes.keys())
         elif queue_type == 'padding_fifo':
             self.queue = tf.PaddingFIFOQueue(capacity=self.capacity,
                                              dtypes=dtypes,
                                              shapes=shapes,
-                                             names=nodes.keys())
+                                             names=self.nodes.keys())
         elif queue_type == 'priority':
             self.queue = tf.PriorityQueue(capacity=self.capacity,
                                           types=dtypes,
                                           shapes=shapes,
-                                          names=nodes.keys())
+                                          names=self.nodes.keys())
         else:
             Exception('Queue type %s not recognized' % queue_type)
 
         if data_batch_size > 1:
-            self.enqueue_op = self.queue.enqueue_many(nodes)
+            self.enqueue_op = self.queue.enqueue_many(self.nodes)
         else:
-            self.enqueue_op = self.queue.enqueue(nodes)
+            self.enqueue_op = self.queue.enqueue(self.nodes)
         self.batch = self.queue.dequeue_many(batch_size)
 
     def thread_main(self, sess):

--- a/tfutils/data.py
+++ b/tfutils/data.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-import threading
+import copy, threading, time
 import numpy as np
 import h5py
 import tensorflow as tf
+from tensorflow.contrib.learn.python.learn.datasets.mnist import read_data_sets
 
 
 class HDF5DataProvider(object):
@@ -30,9 +31,7 @@ class HDF5DataProvider(object):
         - mini_batch_size (int):  Used only if subslice is specifiied, this sets the size of minibatches used
           when constructing one full batch within the subslice to return
         - preprocess (dict of callables): functions for preprocessing data in the datasources.  keys of this are subset
-          of sourcelist. preprocessing is done on object instantiation
         - postprocess (dict of callables): functions for postprocess data.  Keys of this are subset of sourcelist.
-          Postprocessing is done when get_batch is called.
         - pad (bool): whether to pad data returned if amount of data left to return is less then full batch size
         """
         self.hdf5source = hdf5source
@@ -50,7 +49,6 @@ class HDF5DataProvider(object):
             if source in self.preprocess:
                 print('Preprocessing %s...' % source)
                 self.data[source] = self.preprocess[source](self.data[source])
-                print('...done')
 
         for source in sourcelist:
             if self.subslice is None:
@@ -194,67 +192,92 @@ def isin(X,Y):
 
 class Queue(object):
     """ A generic queue for reading data
-        Based on https://indico.io/blog/tensorflow-data-input-part2-extensions/
+        Built on top of https://indico.io/blog/tensorflow-data-input-part2-extensions/
     """
 
     def __init__(self,
-                 node,
-                 data_iter,
+                 data,
+                 data_batch_size=None,
                  queue_type='fifo',
                  batch_size=256,
                  n_threads=4,
+                 capacity=None,
                  seed=0):
-        self.node = node
-        self.data_iter = data_iter
+        self.data_iter = iter(data)
         self.batch_size = batch_size
         self.n_threads = n_threads
-
-        dtypes = [d.dtype for d in node.values()]
-        if self.data_iter.batch_size > 1:
-            shapes = [d.get_shape()[1:] for d in node.values()]
+        if capacity is None:
+            self.capacity = self.n_threads * self.batch_size * 2
         else:
-            shapes = [d.get_shape() for d in node.values()]
+            self.capacity = capacity
+
+        if data_batch_size is None:
+            try:
+                data_batch_size = self.data_iter.batch_size
+            except KeyError:
+                raise KeyError('Need to define data batch size; either pass it '
+                               'to Queue constructor or have it defined in '
+                               'data_iter.batch_size.')
+
+        nodes = {}
+        dtypes = []
+        shapes = []
+        self._first_batch = self.data_iter.next()
+        for key, value in self._first_batch.items():
+            nodes[key] = tf.placeholder(value.dtype, shape=value.shape, name=key)
+            dtypes.append(value.dtype)
+            if data_batch_size > 1:
+                shapes.append(value.shape[1:])
+            else:
+                shapes.append(value.shape)
 
         if queue_type == 'random':
-            self.queue = tf.RandomShuffleQueue(capacity=n_threads * batch_size * 2,
-                                               min_after_dequeue=n_threads * batch_size,
+            self.queue = tf.RandomShuffleQueue(capacity=self.capacity,
+                                               min_after_dequeue=self.capacity // 2,
                                                dtypes=dtypes,
                                                shapes=shapes,
-                                               names=node.keys(),
+                                               names=nodes.keys(),
                                                seed=seed)
         elif queue_type == 'fifo':
-            self.queue = tf.FIFOQueue(capacity=n_threads * batch_size * 2,
+            self.queue = tf.FIFOQueue(capacity=self.capacity,
                                       dtypes=dtypes,
                                       shapes=shapes,
-                                      names=node.keys())
+                                      names=nodes.keys())
         elif queue_type == 'padding_fifo':
-            self.queue = tf.PaddingFIFOQueue(capacity=n_threads * batch_size * 2,
+            self.queue = tf.PaddingFIFOQueue(capacity=self.capacity,
                                              dtypes=dtypes,
                                              shapes=shapes,
-                                             names=node.keys())
+                                             names=nodes.keys())
         elif queue_type == 'priority':
-            self.queue = tf.PriorityQueue(capacity=n_threads * batch_size * 2,
+            self.queue = tf.PriorityQueue(capacity=self.capacity,
                                           types=dtypes,
                                           shapes=shapes,
-                                          names=node.keys())
+                                          names=nodes.keys())
         else:
             Exception('Queue type %s not recognized' % queue_type)
 
-        if self.data_iter.batch_size > 1:
-            self.enqueue_op = self.queue.enqueue_many(node)
+        if data_batch_size > 1:
+            self.enqueue_op = self.queue.enqueue_many(nodes)
         else:
-            self.enqueue_op = self.queue.enqueue(node)
+            self.enqueue_op = self.queue.enqueue(nodes)
         self.batch = self.queue.dequeue_many(batch_size)
 
     def thread_main(self, sess):
         """
         Function run on alternate thread. Basically, keep adding data to the queue.
         """
-        for batch in self.data_iter:
-            try:
-                sess.run(self.enqueue_op, feed_dict=batch)
-            except tf.errors.CancelledError:
-                break
+        try:
+            feed_dict = {node: self._first_batch[name] for name, node in self.nodes.items()}
+            sess.run(self.enqueue_op, feed_dict=feed_dict)
+        except tf.errors.CancelledError:
+            pass
+        else:
+            for batch in self.data_iter:
+                try:
+                    feed_dict = {node: batch[name] for name, node in self.nodes.items()}
+                    sess.run(self.enqueue_op, feed_dict=feed_dict)
+                except tf.errors.CancelledError:
+                    break
 
     def start_threads(self, sess):
         """ Start background threads to feed queue """
@@ -264,11 +287,49 @@ class Queue(object):
             t.daemon = True  # thread will close when parent quits
             t.start()
             threads.append(t)
-        return threads
+        self.threads = threads
 
     def stop_threads(self, sess):
         close_op = self.queue.close(cancel_pending_enqueues=True)
         sess.run(close_op)
+
+
+class MNIST(object):
+    def __init__(self,
+                 data_path=None,
+                 group='train',
+                 batch_size=100):
+        """
+        A specific reader for IamgeNet stored as a HDF5 file
+
+        Kwargs:
+            - data_path: path to imagenet data
+            - group: train, validation, test
+            - batch_size
+        """
+        self.batch_size = batch_size
+
+        if data_path is None:
+            data_path = '/tmp'
+        data = read_data_sets(data_path)
+
+        if group == 'train':
+            self.data = data.train
+        elif group == 'test':
+            self.data = data.test
+        elif group == 'validation':
+            self.data = data.validation
+            self.total_batches = data.validation.num_examples // self.batch_size
+        else:
+            raise ValueError('MNIST data input "{}" not known'.format(group))
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        batch = self.data.next_batch(self.batch_size)
+        feed_dict = {'images': batch[0], 'labels': batch[1]}
+        return feed_dict
 
 
 class ImageNet(HDF5DataProvider):

--- a/tfutils/tests/test.py
+++ b/tfutils/tests/test.py
@@ -178,7 +178,7 @@ def test_feature_extraction():
 
     targdict = {'func': get_extraction_target,
                 'to_extract': {'features': 'validation/valid1/hidden1/fc:0'}}
-    targdict.update(base.get_default_loss_params())
+    targdict.update(base.DEFAULT_LOSS_PARAMS)
     params['validation_params'] = {'valid1': {'data_params': {'func': MNIST,
                                                               'batch_size': 100,
                                                               'group': 'train'},

--- a/tfutils/tests/test.py
+++ b/tfutils/tests/test.py
@@ -46,12 +46,12 @@ class MNIST(object):
                 'labels': batch[1].astype(np.int32)}
 
 
-
 num_batches_per_epoch = 10000//256
 testhost = 'localhost'
 testport = 31001
 testdbname = 'tfutils-test'
 testcol = 'testcol'
+
 
 def test_training():
     """This test illustrates how basic training is performed.

--- a/tfutils/tests/test.py
+++ b/tfutils/tests/test.py
@@ -144,7 +144,7 @@ def test_validation():
                           port=testport)
     assert conn[testdbname][testcol+'.files'].find({'exp_id': 'validation0'}).count() == 1
     r = conn[testdbname][testcol+'.files'].find({'exp_id': 'validation0'})[0]
-    assert r['validation_only'] == True
+    assert r['validates']
     f = r['validation_results']['valid0']['loss']
     idval = conn[testdbname][testcol+'.files'].find({'exp_id': 'training0'})[50]['_id']
     v = conn[testdbname][testcol+'.files'].find({'exp_id': 'validation0'})[0]['validates']

--- a/tfutils/tests/test.py
+++ b/tfutils/tests/test.py
@@ -78,9 +78,9 @@ def test_training():
                              'save_valid_freq': 20,
                              'save_filters_freq': 200,
                              'cache_filters_freq': 100}
-    params['train_params'] = {'data': {'func': MNIST,
-                                       'batch_size': 100,
-                                       'group': 'train'},
+    params['train_params'] = {'data_params': {'func': MNIST,
+                                              'batch_size': 100,
+                                              'group': 'train'},
                               'queue_params': {'queue_type': 'fifo',
                                                'batch_size': 100,
                                                'n_threads': 4},
@@ -128,10 +128,9 @@ def test_validation():
                              'collname': testcol,
                              'exp_id': 'training0'}
     params['save_params'] = {'exp_id': 'validation0'}
-    params['validation_params'] = {'valid0': {'data': {'func': MNIST,
-                                                       'batch_size': 100,
-                                                       'group': 'train'
-                                                   },
+    params['validation_params'] = {'valid0': {'data_params': {'func': MNIST,
+                                                              'batch_size': 100,
+                                                              'group': 'train'},
                                               'queue_params': {'queue_type': 'fifo',
                                                                'batch_size': 100,
                                                                'n_threads': 4},
@@ -180,16 +179,15 @@ def test_feature_extraction():
     targdict = {'func': get_extraction_target,
                 'to_extract': {'features': 'validation/valid1/hidden1/fc:0'}}
     targdict.update(base.get_default_loss_params())
-    params['validation_params'] = {'valid1': {'data': {'func': MNIST,
-                                                     'batch_size': 100,
-                                                     'group': 'train'
-                                                 },
-                                            'targets': targdict,
-                                            'queue_params': {'queue_type': 'fifo',
-                                                             'batch_size': 100,
-                                                             'n_threads': 4},
-                                            'num_steps': 10,
-                                            'online_agg_func': utils.reduce_mean_dict
+    params['validation_params'] = {'valid1': {'data_params': {'func': MNIST,
+                                                              'batch_size': 100,
+                                                              'group': 'train'},
+                                              'queue_params': {'queue_type': 'fifo',
+                                                               'batch_size': 100,
+                                                               'n_threads': 4},
+                                              'targets': targdict,
+                                              'num_steps': 10,
+                                              'online_agg_func': utils.reduce_mean_dict
                                             }
                                    }
     base.test_from_params(**params)

--- a/tfutils/tests/test.py
+++ b/tfutils/tests/test.py
@@ -155,7 +155,6 @@ def test_validation():
     can be loaded for inspection.)
 
     See the docstring of tfutils.base.test_from_params for more detailed information on usage.
-
     """
     #specify the parameters for the validation
     params = {}
@@ -224,7 +223,6 @@ def test_feature_extraction():
     This is a test illustrating how to perform feature extraction using tfutils.base.test_from_params. 
     The basic idea is to specify a validation target that is simply the actual output of the model at some layer. 
     (See the "get_extraction_target" function above as well.)  This test assumes that test_train has run first. 
-
    
     After the test is run, the results of the feature extraction are saved in the Grid File System associated
     with the mongodb, with one file per batch of feature results.  See how the features are accessed by reading the

--- a/tfutils/utils.py
+++ b/tfutils/utils.py
@@ -190,6 +190,13 @@ def get_loss_dict(*args, **kwargs):
     return {name: get_loss(*args, **kwargs)}
 
 
+def verify_pb2_v2_files(cache_prefix, ckpt_record):
+    file_data = get_saver_pb2_v2_files(cache_prefix)
+    ndf = file_data['num_data_files']
+    sndf = ckpt_record['_saver_num_data_files']
+    assert ndf == sndf, (ndf, sndf)
+
+
 def get_saver_pb2_v2_files(prefix):
     dirn, pref = os.path.split(prefix)
     pref = pref + '.'

--- a/tfutils/utils.py
+++ b/tfutils/utils.py
@@ -9,6 +9,7 @@ import re
 import copy
 import threading
 
+
 import numpy as np
 from bson.objectid import ObjectId
 import git
@@ -262,3 +263,46 @@ def mean_dict(y):
         else:
             x[ka] = [min(pluck), max(pluck)]
     return x
+
+
+class frozendict(collections.Mapping):
+    """
+    An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
+    interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.
+
+    from https://pypi.python.org/pypi/frozendict
+
+    """
+
+    dict_cls = dict
+
+    def __init__(self, *args, **kwargs):
+        self._dict = self.dict_cls(*args, **kwargs)
+        self._hash = None
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def copy(self, **add_or_replace):
+        return self.__class__(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __repr__(self):
+        return '<%s %r>' % (self.__class__.__name__, self._dict)
+
+    def __hash__(self):
+        if self._hash is None:
+            h = 0
+            for key, value in iteritems(self._dict):
+                h ^= hash((key, value))
+            self._hash = h
+        return self._hash
+

--- a/tfutils/utils.py
+++ b/tfutils/utils.py
@@ -261,23 +261,3 @@ def mean_dict(y):
         else:
             x[ka] = [min(pluck), max(pluck)]
     return x
-
-from threading import Thread
-
-def foo(bar):
-    print 'hello {0}'.format(bar)
-    return "foo"
-
-
-class ThreadWithReturnValue(threading.Thread):
-    def __init__(self, group=None, target=None, name=None,
-                 args=(), kwargs={}, Verbose=None):
-        Thread.__init__(self, group, target, name, args, kwargs, Verbose)
-        self._return = None
-    def run(self):
-        if self._Thread__target is not None:
-            self._return = self._Thread__target(*self._Thread__args,
-                                                **self._Thread__kwargs)
-    def join(self):
-        Thread.join(self)
-        return self._return

--- a/tfutils/utils.py
+++ b/tfutils/utils.py
@@ -167,14 +167,15 @@ def jsonize(x):
 
 def get_loss(inputs,
              outputs,
-             target,
+             targets,
              loss_per_case_func,
              agg_func=None,
              loss_func_kwargs=None,
              agg_func_kwargs=None):
     if loss_func_kwargs is None:
         loss_func_kwargs = {}
-    loss = loss_per_case_func(outputs, inputs[target], **loss_func_kwargs)
+    args = tuple([inputs[t] for t in targets])
+    loss = loss_per_case_func(outputs, *args, **loss_func_kwargs)
     if agg_func is not None:
         if agg_func_kwargs is None:
             agg_func_kwargs = {}


### PR DESCRIPTION
@qbilius  Ok I've done a bunch of what we talked about:

1) integrated with new queue interface
2) largely modularized the logic of the "call_" blocks (I've called them "get_*") to try to make the logic and default arguments clearer
3) dealt with the issue of the step=0 stuff
4) ... and a variety of other small things.
5) and added a bunch of detail in the tests and debugged the code accordingly. 

I have not separated the load and save methods for the DBInterface object into two different subclasses.  I'm not yet entirely convinced of the wisdom of doing this.   Can we review/merge the existing PR and then possibly deal with that issue later?  



