### PR TITLE
Changes to do enqueue of batch_size of 1

### DIFF
--- a/tfutils/base.py
+++ b/tfutils/base.py
@@ -1184,7 +1184,7 @@ def get_data(func, queue_params=None, **data_params):
     batch_size = data_params['batch_size']
     data_params['func'] = func
     enqueue_ops = []
-    queue = get_queue(input_ops[0], **queue_params)
+    queue = get_queue(input_ops[0], shape_flag = batch_size!=1, **queue_params)
     for input_op in input_ops:
         if batch_size == 1:
             enqueue_ops.append(queue.enqueue(input_op))

--- a/tfutils/data.py
+++ b/tfutils/data.py
@@ -673,7 +673,8 @@ def get_queue(nodes,
               batch_size=256,
               capacity=None,
               min_after_dequeue=None,
-              seed=0):
+              seed=0,
+              shape_flag = True):
     """ A generic queue for reading data
         Built on top of https://indico.io/blog/tensorflow-data-input-part2-extensions/
     """
@@ -689,7 +690,10 @@ def get_queue(nodes,
     for name in nodes.keys():
         names.append(name)
         dtypes.append(nodes[name].dtype)
-        shapes.append(nodes[name].get_shape()[1:])
+        if shape_flag:
+            shapes.append(nodes[name].get_shape()[1:])
+        else:
+            shapes.append(nodes[name].get_shape())
 
     if batch_size==1:
         shapes = None


### PR DESCRIPTION
For enqueue rather than enqueue_many, the first dimension of the shape arguments sent into the queue initialization function should not be excluded. (One also need to do shape setting and squeezing in their data_providers for the first dimension)