### PR TITLE
Option to include global step passed to optimizer class

### DIFF
--- a/tfutils/helper.py
+++ b/tfutils/helper.py
@@ -193,7 +193,6 @@ def get_optimizer(
 
     # Build the optimizer, use class MinibatchOptimizer as a wrapper
     if include_global_step:
-        print('TFUTILS global step', global_step)
         optimizer_base = MinibatchOptimizer(
             optimizer=optimizer,
             learning_rate=learning_rate,

--- a/tfutils/helper.py
+++ b/tfutils/helper.py
@@ -108,6 +108,8 @@ def get_model(inputs, model_params, var_manager=None, param=None, trarg=None):
                     param['optimizer_params'], optimizer_base \
                             = get_optimizer(
                                     learning_rate,
+                                    trarg['global_step'],
+                                    param['train_params'].get('include_global_step'),
                                     param['optimizer_params'])
                     tower_opts.append(optimizer_base)
 
@@ -175,7 +177,9 @@ def get_learning_rate(global_step,
 
 def get_optimizer(
         learning_rate,
-        optimizer_params,
+        global_step,
+        include_global_step,
+        optimizer_params
         ):
     if not optimizer_params:
         optimizer_params = dict(DEFAULT_PARAMS['optimizer_params'])
@@ -188,7 +192,15 @@ def get_optimizer(
         optimizer = func
 
     # Build the optimizer, use class MinibatchOptimizer as a wrapper
-    optimizer_base = MinibatchOptimizer(
+    if include_global_step:
+        print('TFUTILS global step', global_step)
+        optimizer_base = MinibatchOptimizer(
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            global_step=global_step, 
+            **optimizer_params)
+    else:
+        optimizer_base = MinibatchOptimizer(
             optimizer=optimizer,
             learning_rate=learning_rate,
             **optimizer_params)


### PR DESCRIPTION
Add option to include global step (passed in train_params) to explicitly pass to optimizer class if need be (sometimes you may want this in your optimizers, whereby you reset a variable or update it based on the global step value), since you cannot do this automatically with tf.train.get_global_step().