### PR TITLE
Compatibility fix for DBInterface on Python 3

### DIFF
--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -4,7 +4,7 @@ import gridfs
 import tarfile
 try:
     import cPickle as pickle
-except ModuleNotFoundError:
+except ImportError:
     import pickle
 from bson.objectid import ObjectId
 import datetime
@@ -234,7 +234,7 @@ def sonify(arg, memo=None, skip=False):
         if arg.ndim == 0:
             rval = sonify(arg.sum(), skip=skip)
         else:
-            rval = map(sonify, arg)  # N.B. memo None
+            rval = list(map(sonify, arg))  # N.B. memo None
     # -- put this after ndarray because ndarray not hashable
     elif arg in (True, False):
         rval = int(arg)

--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -644,7 +644,7 @@ class DBInterface(object):
                 # create new file to write from gridfs
                 load_dest = open(cache_filename, "w+")
                 load_dest.close()
-                load_dest = open(cache_filename, 'rwb+')
+                load_dest = open(cache_filename, 'rb+')
                 fsbucket = gridfs.GridFSBucket(database, bucket_name=loading_from.name.split('.')[0])
                 fsbucket.download_to_stream(ckpt_record['_id'], load_dest)
                 load_dest.close()

--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -644,7 +644,7 @@ class DBInterface(object):
                 # create new file to write from gridfs
                 load_dest = open(cache_filename, "w+")
                 load_dest.close()
-                load_dest = open(cache_filename, 'rb+')
+                load_dest = open(cache_filename, 'wb+')
                 fsbucket = gridfs.GridFSBucket(database, bucket_name=loading_from.name.split('.')[0])
                 fsbucket.download_to_stream(ckpt_record['_id'], load_dest)
                 load_dest.close()

--- a/tfutils/tests/test_base.py
+++ b/tfutils/tests/test_base.py
@@ -10,7 +10,7 @@ import errno
 import shutil
 try:
     import cPickle as pickle
-except ModuleNotFoundError:
+except ImportError:
     import pickle
 import logging
 import unittest


### PR DESCRIPTION
-  I was working with an install of Python 3.5.2 and got an error with the name `ModuleNotFoundError ` not being found. It was not introduced until Python 3.6. I understand if we do not want to support earlier versions of Python 3, though. `ImportError` is the super class of `ModuleNotFoundError ` and would be compatible with Python < 3.6 . 
 - I also found that the default behavior of `map` in that version of Python is similar to a generator, whereas on Python 2 it directly returns the mapped list. Thus, the current version crashes when trying to save the `map` object. (See: https://stackoverflow.com/questions/50671360/map-in-python-3-vs-python-2)