### PR TITLE
When restoring a model, logs variables in checkpoint not in graph

### DIFF
--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -465,7 +465,7 @@ class DBInterface(object):
 
                 # Actually load the vars.
                 log.info('Restored Vars (in ckpt, in graph):\n'
-                         str(restore_names))
+                         + str(restore_names))
                 tf_saver_restore = tf.train.Saver(restore_vars)
                 tf_saver_restore.restore(self.sess, ckpt_filename)
                 log.info('... done restoring.')
@@ -485,7 +485,7 @@ class DBInterface(object):
                         for name, var in self.var_list.items() \
                         if name not in restore_names]
                 log.info('Unrestored Vars (in graph, not in ckpt):\n'
-                         str(unrestored_var_names))
+                         + str(unrestored_var_names))
                 self.sess.run(tf.variables_initializer(unrestored_vars))  # initialize variables not restored
                 assert len(self.sess.run(tf.report_uninitialized_variables())) == 0, (
                     self.sess.run(tf.report_uninitialized_variables()))

--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -363,7 +363,7 @@ class DBInterface(object):
             load_query = {}
         else:
             # Special situation here
-            # Users try to load from the same place they try to save through 
+            # Users try to load from the same place they try to save through
             # setting the load_query
             # This is not allowed
             if self.sameloc and (not save_params == {}):
@@ -396,7 +396,7 @@ class DBInterface(object):
 
         # Set the cache_dir: where to put local cache files
         # use cache_dir from load params if save_params not given
-        if (save_params == {}) and ('cache_dir' in load_params): 
+        if (save_params == {}) and ('cache_dir' in load_params):
             cache_dir = load_params['cache_dir']
         elif 'cache_dir' in save_params:
             cache_dir = save_params['cache_dir']
@@ -464,7 +464,8 @@ class DBInterface(object):
                     restore_names = new_restore_names
 
                 # Actually load the vars.
-                log.info('Restored Vars:\n' + str(restore_names))
+                log.info('Restored Vars (in ckpt, in graph):\n'
+                         str(restore_names))
                 tf_saver_restore = tf.train.Saver(restore_vars)
                 tf_saver_restore.restore(self.sess, ckpt_filename)
                 log.info('... done restoring.')
@@ -483,7 +484,8 @@ class DBInterface(object):
                         name \
                         for name, var in self.var_list.items() \
                         if name not in restore_names]
-                log.info('Unrestored Vars:\n' + str(unrestored_var_names))
+                log.info('Unrestored Vars (in graph, not in ckpt):\n'
+                         str(unrestored_var_names))
                 self.sess.run(tf.variables_initializer(unrestored_vars))  # initialize variables not restored
                 assert len(self.sess.run(tf.report_uninitialized_variables())) == 0, (
                     self.sess.run(tf.report_uninitialized_variables()))
@@ -537,6 +539,14 @@ class DBInterface(object):
             restore_vars = load_var_dict
 
         restore_vars = self.filter_var_list(restore_vars)
+
+        # These variables are stored in the checkpoint,
+        # but do not appear in the current graph
+        in_ckpt_not_in_graph = [ \
+                name \
+                for name in var_shapes.keys() \
+                if name not in all_vars.keys()]
+        log.info('Vars in ckpt, not in graph:\n' + str(in_ckpt_not_in_graph))
 
         # Ensure the vars to restored have the correct shape.
         var_list = {}
@@ -828,7 +838,7 @@ class DBInterface(object):
                 if num_cached_filters > cache_max_num:
                     log.info('Cleaning up cached filters')
                     fsbucket = gridfs.GridFSBucket(
-                            recent_gridfs_files._Collection__database, 
+                            recent_gridfs_files._Collection__database,
                             bucket_name=recent_gridfs_files.name.split('.')[0])
 
                     for del_indx in range(0, num_cached_filters - cache_max_num):
@@ -856,7 +866,7 @@ class CoordinatedThread(threading.Thread):
     """A thread class coordinated by tf.train.Coordinator."""
 
     def __init__(
-            self, coord=None, group=None, 
+            self, coord=None, group=None,
             target=None, name=None, args=(), kwargs={}):
         super(CoordinatedThread, self).__init__(
             group=None, target=target, name=name, args=args, kwargs=kwargs)

--- a/tfutils/db_interface.py
+++ b/tfutils/db_interface.py
@@ -28,7 +28,7 @@ from six import string_types
 from tfutils.utils import strip_prefix_from_name, \
         strip_prefix, get_var_list_wo_prefix
 from tfutils.helper import log
-from tfutils.defaults import DEFAULT_SAVE_PARAMS, DEFAULT_LOAD_PARAMS
+from tfutils.defaults import DEFAULT_SAVE_PARAMS, DEFAULT_LOAD_PARAMS, OPTIMIZER_NAMES
 
 if 'TFUTILS_HOME' in os.environ:
     TFUTILS_HOME = os.environ['TFUTILS_HOME']
@@ -545,7 +545,7 @@ class DBInterface(object):
         in_ckpt_not_in_graph = [ \
                 name \
                 for name in var_shapes.keys() \
-                if name not in all_vars.keys()]
+                if (name not in all_vars.keys()) and (not any([name.endswith(s) for s in OPTIMIZER_NAMES]))]
         log.info('Vars in ckpt, not in graph:\n' + str(in_ckpt_not_in_graph))
 
         # Ensure the vars to restored have the correct shape.

--- a/tfutils/defaults.py
+++ b/tfutils/defaults.py
@@ -7,6 +7,8 @@ import tensorflow as tf
 
 from tfutils.multi_gpu.easy_variable_mgr import COPY_NAME_SCOPE
 
+OPTIMIZER_NAMES = ['Momentum', 'Adam', 'Adagrad', 'RMSProp']
+
 DEFAULT_TPU_ZONE = None
 DEFAULT_NUM_SHARDS = 8
 DEFAULT_ITERATIONS_PER_LOOP = 100


### PR DESCRIPTION
When restoring models, I've found it useful to see the full picture of which variables were restored and which were not. We have two overlapping sets of variables: the variables in the checkpoint and the variables in the graph. 

We currently log:
- Restored vars: variables in the graph and in the checkpoint, whose shapes in both places match
- Unrestored vars: variables in the graph which were not in the checkpoint. These are initialized randomly. 

I propose also logging variables in the checkpoint, not in the graph. This might help verify that the relevant checkpoint vars were restored, in case the current graph is only a subset of the checkpoint being loaded. 

Potential improvements: 
- Filter out `global_step` and all the optimizer variables (e.g. `Momentum`) - which are clearly in the checkpoint and will not be restored - to get cleaner output. 