### PR TITLE
Uses a single parameter to toggle between using tpu or not

### DIFF
--- a/tfutils/imagenet_data.py
+++ b/tfutils/imagenet_data.py
@@ -314,6 +314,14 @@ class ImageNet(object):
         return dataset
 
     def dataset_func(
+        self, *args, **kwargs
+    ):
+        if self.on_tpu:
+            return self.dataset_func_tpu(*args, **kwargs)
+        else:
+            return self.dataset_func_gpu(*args, **kwargs)
+
+    def dataset_func_gpu(
         self,
         is_train,
         batch_size,
@@ -346,6 +354,7 @@ class ImageNet(object):
         Build the dataset, get the elements
         """
 
+        self.is_train = params['is_train']
         if self.is_train:
             self.file_pattern = 'train-*'
         else:

--- a/tfutils/imagenet_data.py
+++ b/tfutils/imagenet_data.py
@@ -60,6 +60,7 @@ class ImageNet(object):
         crop_size=224,
         smallest_side=256,
         resize=None,
+        is_train=True,
         drop_remainder=False
     ):
         self.image_dir = image_dir
@@ -70,14 +71,13 @@ class ImageNet(object):
         self.smallest_side = smallest_side
         self.resize = resize
         self.num_cores = 8
-        self.on_tpu = on_tpu
 
         self.drop_remainder = drop_remainder
+        self.is_train = is_train
 
         # Placeholders to be filled later
         self.on_tpu = None
         self.file_pattern = None
-        self.is_train = None
 
     def get_tfr_filenames(self):
         """
@@ -345,7 +345,6 @@ class ImageNet(object):
         self.on_tpu = True
         self.drop_remainder = True
 
-        self.is_train = params['is_train']
         if self.is_train:
             self.file_pattern = 'train-*'
         else:

--- a/tfutils/imagenet_data.py
+++ b/tfutils/imagenet_data.py
@@ -60,7 +60,6 @@ class ImageNet(object):
         crop_size=224,
         smallest_side=256,
         resize=None,
-        is_train=False,
         drop_remainder=False,
         on_tpu=False
     ):
@@ -81,7 +80,7 @@ class ImageNet(object):
 
         # Placeholders to be filled later
         self.file_pattern = None
-        self.is_train = is_train
+        self.is_train = None
 
     def get_tfr_filenames(self):
         """

--- a/tfutils/imagenet_data.py
+++ b/tfutils/imagenet_data.py
@@ -60,8 +60,7 @@ class ImageNet(object):
         crop_size=224,
         smallest_side=256,
         resize=None,
-        drop_remainder=False,
-        on_tpu=False
+        drop_remainder=False
     ):
         self.image_dir = image_dir
 
@@ -73,12 +72,10 @@ class ImageNet(object):
         self.num_cores = 8
         self.on_tpu = on_tpu
 
-        if self.on_tpu:
-            self.drop_remainder = True
-        else:
-            self.drop_remainder = drop_remainder
+        self.drop_remainder = drop_remainder
 
         # Placeholders to be filled later
+        self.on_tpu = None
         self.file_pattern = None
         self.is_train = None
 
@@ -313,14 +310,6 @@ class ImageNet(object):
         return dataset
 
     def dataset_func(
-        self, *args, **kwargs
-    ):
-        if self.on_tpu:
-            return self.dataset_func_tpu(*args, **kwargs)
-        else:
-            return self.dataset_func_gpu(*args, **kwargs)
-
-    def dataset_func_gpu(
         self,
         is_train,
         batch_size,
@@ -330,6 +319,7 @@ class ImageNet(object):
         """
         Build the dataset, get the elements
         """
+        self.on_tpu = False
         self.is_train = is_train
         self.file_pattern = file_pattern
         self.batch_size = batch_size
@@ -352,6 +342,8 @@ class ImageNet(object):
         """
         Build the dataset, get the elements
         """
+        self.on_tpu = True
+        self.drop_remainder = True
 
         self.is_train = params['is_train']
         if self.is_train:


### PR DESCRIPTION
I found it weird that to use this unified data provider on tpu you have to specify you are doing things on tpu twice: once with the `on_tpu` arg in the constructor, and once when you choose which function to pass in the data params dictionary. 

I also thought it would be best if we keep things consistent between gpu and tpu and I removed `is_train` from the constructor args, and pass it via the kwargs in the dataset func. 

With this, usage would go from 
```
'data_params': {
            'func': ImageNet(image_dir=FLAGS.data_dir,
                             prep_type='resnet',
                             on_tpu=True,
                             is_train=True,
                             resize=FLAGS.image_size).dataset_func_tpu,
            'batch_size': FLAGS.train_batch_size
        }
```
to this, which would only differ from a GPU call in the `on_tpu` argument. 
```
'data_params': {
            'func': ImageNet(image_dir=FLAGS.data_dir,
                             prep_type='resnet',
                             on_tpu=True,
                             resize=FLAGS.image_size).dataset_func,
            'is_train': True,
            'batch_size': FLAGS.train_batch_size
        }
```