### PR TITLE
Sets a version limit on tensorflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy', 'tensorflow-gpu', 'pymongo', 'tqdm', 'gitpython'],
+    install_requires=['numpy', 'tensorflow-gpu<1.14', 'pymongo', 'tqdm', 'gitpython'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Now that tf 1.14 and tf 2.0b1 are out, if tensorflow is not installed on a system, the setup script would install the latest possible version and I don't think we are 2.0 compatible yet? 

Might also be a good idea to set version ranges on the other dependencies?