### PR TITLE
Load param dict

### DIFF
--- a/tfutils/tests/test_dbinterface.py
+++ b/tfutils/tests/test_dbinterface.py
@@ -131,8 +131,9 @@ class TestDBInterface(unittest.TestCase):
 
         self.log.info('restore_vars:')
         for name, var in restore_vars.items():
-            self.log.info('(name, var.name): ({}, {})'.format(name, var.name))
-            self.assertEqual(var.op.name, mapping[name])
+            if name in mapping.keys():
+                self.log.info('(name, var.name): ({}, {})'.format(name, var.name))
+                self.assertEqual(var.op.name, mapping[name])
 
     def test_filter_var_list(self):
 


### PR DESCRIPTION
Updating load param dict feature to only require specifying the variables to be restored that you want to remap, rather than having to specify all the restored variables in the graph (including the ones you do not need to remap).