### PR TITLE
Adds functionality to train on TPU pods or slices

### DIFF
--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -273,7 +273,7 @@ def create_train_estimator_fn(use_tpu,
                eval_metrics = eval_dict
 
         if use_tpu:
-            return tpu_estimator.TPUEstimatorSpec(
+            return tf.contrib.tpu.TPUEstimatorSpec(
               mode=mode,
               loss=loss,
               train_op=train_op,
@@ -359,25 +359,26 @@ def create_train_tpu_config(model_dir,
             tpu=[tpu_name],
             zone=tpu_zone,
             project=gcp_project))
-    tpu_grpc_url = tpu_cluster_resolver.get_master()
+    tpu_grpc_url = tpu_cluster_resolver.get_master() # might not need this
 
     if iterations_per_loop == -1 or (steps_per_checkpoint is not None and steps_per_checkpoint < iterations_per_loop):
         log.info('Setting iterations_per_loop ({}) to be the same as steps_per_checkpoint ({}).'.format(iterations_per_loop, steps_per_checkpoint))
         iterations_per_loop = steps_per_checkpoint
         model_params['iterations_per_loop'] = iterations_per_loop
 
-    config = tpu_config.RunConfig(
-        master=tpu_grpc_url,
-        evaluation_master=tpu_grpc_url,
+    config = tf.estimator.tpu.RunConfig(
+        #master=tpu_grpc_url,
+        #evaluation_master=tpu_grpc_url,
+        cluster=tpu_cluster_resolver,
         model_dir=model_dir,
         save_checkpoints_steps=steps_per_checkpoint,
-        save_checkpoints_secs=None,
-        keep_checkpoint_max=keep_checkpoint_max,
-        log_step_count_steps=iterations_per_loop,
-        tpu_config=tpu_config.TPUConfig(
+        save_checkpoints_secs=None, # check
+        keep_checkpoint_max=keep_checkpoint_max, # check
+        log_step_count_steps=iterations_per_loop, # check
+        tpu_config=tf.estimator.tpu.TPUConfig(
             iterations_per_loop=iterations_per_loop,
             num_shards=num_shards,
-            per_host_input_for_training=tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2))
+            per_host_input_for_training=tf.estimator.tpu.InputPipelineConfig.PER_HOST_V2))
 
     return config
 

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -236,44 +236,44 @@ def create_train_estimator_fn(use_tpu,
 
         eval_metrics = None
         if mode == tf.estimator.ModeKeys.EVAL:
-           num_valid_targets = len(validation_params.keys())
-           metric_fn_kwargs = {'labels': labels, 'logits': logits}
-           if use_tpu:
-               assert(num_valid_targets==1) # tpu estimators currently only support single targets :(
-               first_valid = validation_params.keys()[0]
-               valid_target = validation_params[first_valid]['targets']
-               metric_fn = valid_target['func']
-               if isinstance(outputs, dict):
-                   for kw in outputs.keys():
-                       if kw != logit_key:
-                           kw_val = outputs[kw]
-                           new_kw = kw
-                           if isinstance(new_kw, int):
-                               new_kw = 'i%i' % new_kw
-                           metric_fn_kwargs.update({new_kw:kw_val})
+            num_valid_targets = len(validation_params.keys())
+            metric_fn_kwargs = {'labels': labels, 'logits': logits}
+            if use_tpu:
+                assert(num_valid_targets==1) # tpu estimators currently only support single targets :(
+                first_valid = validation_params.keys()[0]
+                valid_target = validation_params[first_valid]['targets']
+                metric_fn = valid_target['func']
+                if isinstance(outputs, dict):
+                    for kw in outputs.keys():
+                        if kw != logit_key:
+                            kw_val = outputs[kw]
+                            new_kw = kw
+                            if isinstance(new_kw, int):
+                                new_kw = 'i%i' % new_kw
+                            metric_fn_kwargs.update({new_kw:kw_val})
 
-               for kw in valid_target.keys():
-                   v = valid_target[kw]
-                   if isinstance(v, dict):
-                       for kw1 in v.keys():
-                           # add any additional kwargs
-                           kw_val = v[kw1]
-                           metric_fn_kwargs.update({kw1: kw_val})
-                           #metric_fn_kwargs[kw] = kw_val
-               eval_metrics = (metric_fn, metric_fn_kwargs)
-           else:
-               # normal estimators expect dicts and can support multiple targets (but same dataset and eval_steps etc)
-               eval_dict = {}
-               for k in validation_params.keys():
-                   k_metric_fn_kwargs = metric_fn_kwargs
-                   k_target = k['targets']
-                   for kw in k_target.keys():
-                       if kw != 'func':
-                           # add any additional kwargs
-                           kw_val = k_target[kw]
-                           k_metric_fn_kwargs[kw] = kw_val
-                   eval_dict[k] = (k_target['func'], k_metric_fn_kwargs)
-               eval_metrics = eval_dict
+                for kw in valid_target.keys():
+                    v = valid_target[kw]
+                    if isinstance(v, dict):
+                        for kw1 in v.keys():
+                            # add any additional kwargs
+                            kw_val = v[kw1]
+                            metric_fn_kwargs.update({kw1: kw_val})
+                            #metric_fn_kwargs[kw] = kw_val
+                eval_metrics = (metric_fn, metric_fn_kwargs)
+            else:
+                # normal estimators expect dicts and can support multiple targets (but same dataset and eval_steps etc)
+                eval_dict = {}
+                for k in validation_params.keys():
+                    k_metric_fn_kwargs = metric_fn_kwargs
+                    k_target = k['targets']
+                    for kw in k_target.keys():
+                        if kw != 'func':
+                            # add any additional kwargs
+                            kw_val = k_target[kw]
+                            k_metric_fn_kwargs[kw] = kw_val
+                    eval_dict[k] = (k_target['func'], k_metric_fn_kwargs)
+                eval_metrics = eval_dict
 
         if use_tpu:
             return tf.contrib.tpu.TPUEstimatorSpec(

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -359,14 +359,14 @@ def create_train_tpu_config(model_dir,
             tpu=[tpu_name],
             zone=tpu_zone,
             project=gcp_project))
-    tpu_grpc_url = tpu_cluster_resolver.get_master() # might not need this
+    tpu_grpc_url = tpu_cluster_resolver.get_master() # might not need this
 
     if iterations_per_loop == -1 or (steps_per_checkpoint is not None and steps_per_checkpoint < iterations_per_loop):
         log.info('Setting iterations_per_loop ({}) to be the same as steps_per_checkpoint ({}).'.format(iterations_per_loop, steps_per_checkpoint))
         iterations_per_loop = steps_per_checkpoint
         model_params['iterations_per_loop'] = iterations_per_loop
 
-    config = tf.estimator.tpu.RunConfig(
+    config = tf.contrib.tpu.RunConfig(
         #master=tpu_grpc_url,
         #evaluation_master=tpu_grpc_url,
         cluster=tpu_cluster_resolver,
@@ -375,10 +375,10 @@ def create_train_tpu_config(model_dir,
         save_checkpoints_secs=None, # check
         keep_checkpoint_max=keep_checkpoint_max, # check
         log_step_count_steps=iterations_per_loop, # check
-        tpu_config=tf.estimator.tpu.TPUConfig(
+        tpu_config=tf.contrib.tpu.TPUConfig(
             iterations_per_loop=iterations_per_loop,
-            num_shards=num_shards,
-            per_host_input_for_training=tf.estimator.tpu.InputPipelineConfig.PER_HOST_V2))
+            num_shards=num_shards))#,
+            #per_host_input_for_training=tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2))
 
     return config
 

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -11,9 +11,12 @@ from tensorflow.contrib.training.python.training import evaluation
 from tensorflow.python.estimator import estimator
 from tensorflow.contrib.tpu.python.tpu import tpu_optimizer
 
-def train_estimator(cls,
+def train_estimator(train_cls,
+                    eval_cls,
                     param,
                     trarg):
+    if eval_cls is None:
+        eval_cls = train_cls
 
     model_dir = param['save_params'].get('cache_dir', '')
     train_steps = param['train_params']['num_steps']
@@ -72,7 +75,7 @@ def train_estimator(cls,
     tpu_validate_first = param['train_params'].get('tpu_validate_first', False)
     def do_tpu_validation():
         log.info('Starting to evaluate.')
-        eval_results = cls.evaluate(
+        eval_results = eval_cls.evaluate(
           input_fn=valid_fn,
           hooks=valid_hooks,
           steps=valid_steps)
@@ -90,7 +93,7 @@ def train_estimator(cls,
                             train_steps)
 
         log.info('Training until step %d' % next_eval)
-        cls.train(
+        train_cls.train(
         input_fn=train_fn, max_steps=next_eval, hooks=train_hooks)
         current_step = next_eval
 

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -35,7 +35,7 @@ def train_estimator(cls,
                 assert(steps_per_eval == save_filters_freq)
             else:
                 param['save_params']['save_filters_freq'] = steps_per_eval
-    train_fn = param['train_params']['data_params']['func'] 
+    train_fn = param['train_params']['data_params']['func']
 
     model_params = param['model_params']
     iterations_per_loop = model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP)
@@ -96,7 +96,7 @@ def train_estimator(cls,
 
         if need_val:
             eval_results = do_tpu_validation()
-    
+
     # sync with hosts
     res = []
     trarg['dbinterface'].sync_with_host()
@@ -129,8 +129,8 @@ def test_estimator(cls_dict,
         cls = cls_dict[valid_k]
         validation_data_params = param['validation_params'][valid_k]['data_params']
         # can use to filter particular params to save, if not there will set to None and all saved
-        filter_keys = param['validation_params'][valid_k].get('keys_to_save') 
-        session_hooks = param['validation_params'][valid_k].get('hooks') 
+        filter_keys = param['validation_params'][valid_k].get('keys_to_save')
+        session_hooks = param['validation_params'][valid_k].get('hooks')
         valid_fn = validation_data_params['func']
         log.info('Starting to evaluate ({}).'.format(valid_k))
         eval_results = cls.predict(
@@ -144,7 +144,7 @@ def test_estimator(cls_dict,
     # set validation only to be True to just save the results and not filters
     ttarg['dbinterface'].save(valid_res=m_predictions, validation_only=True)
     log.info('Done saving eval results to database.')
-    
+
     # sync with hosts
     res = []
     ttarg['dbinterface'].sync_with_host()
@@ -152,7 +152,7 @@ def test_estimator(cls_dict,
     # returning final eval results for convenience
     return eval_results, res
 
-def create_train_estimator_fn(use_tpu, 
+def create_train_estimator_fn(use_tpu,
                         model_params,
                         lr_params,
                         opt_params,
@@ -162,7 +162,7 @@ def create_train_estimator_fn(use_tpu,
     """
     Creates a model_fn for use with tf.Estimator for training and eval.
     """
-    # set up loss params 
+    # set up loss params
     loss_agg_func = loss_params.get('agg_func', DEFAULT_TPU_LOSS_PARAMS['agg_func'])
 
     loss_per_case_func = loss_params.get('loss_per_case_func', DEFAULT_TPU_LOSS_PARAMS['loss_per_case_func'])
@@ -202,7 +202,7 @@ def create_train_estimator_fn(use_tpu,
             logits = outputs[logit_key]
         else:
             logits = outputs
-            
+
         loss_args = (outputs, labels)
         loss = loss_per_case_func(*loss_args, **loss_func_kwargs)
         loss = loss_agg_func(loss, **loss_agg_func_kwargs)
@@ -268,7 +268,7 @@ def create_train_estimator_fn(use_tpu,
                        if kw != 'func':
                            # add any additional kwargs
                            kw_val = k_target[kw]
-                           k_metric_fn_kwargs[kw] = kw_val                       
+                           k_metric_fn_kwargs[kw] = kw_val
                    eval_dict[k] = (k_target['func'], k_metric_fn_kwargs)
                eval_metrics = eval_dict
 
@@ -287,7 +287,7 @@ def create_train_estimator_fn(use_tpu,
 
     return model_fn, params_to_pass
 
-def create_test_estimator_fn(use_tpu, 
+def create_test_estimator_fn(use_tpu,
                         model_params,
                         target_params):
 
@@ -328,8 +328,8 @@ def create_test_estimator_fn(use_tpu,
                if kw != 'func':
                    # add any additional kwargs
                    kw_val = k_target[kw]
-                   k_metric_fn_kwargs[kw] = kw_val   
-           k_target_func = k_target.pop('func')                       
+                   k_metric_fn_kwargs[kw] = kw_val
+           k_target_func = k_target.pop('func')
            eval_dict['predictions'] = k_target_func(**k_metric_fn_kwargs)
            predictions = eval_dict
 
@@ -376,7 +376,8 @@ def create_train_tpu_config(model_dir,
         log_step_count_steps=iterations_per_loop,
         tpu_config=tpu_config.TPUConfig(
             iterations_per_loop=iterations_per_loop,
-            num_shards=num_shards))
+            num_shards=num_shards,
+            per_host_input_for_training=tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2))
 
     return config
 
@@ -402,6 +403,7 @@ def create_test_tpu_config(model_dir,
         log_step_count_steps=iterations_per_loop,
         tpu_config=tpu_config.TPUConfig(
             iterations_per_loop=eval_steps,
-            num_shards=num_shards))
+            num_shards=num_shards,
+            per_host_input_for_training=tf.contrib.tpu.InputPipelineConfig.PER_HOST_V2))
 
     return config

--- a/tfutils/tpu_train.py
+++ b/tfutils/tpu_train.py
@@ -56,7 +56,7 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
                                      iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
                                      model_params=model_params)
 
-        estimator_classifier = tf.estimator.tpu.TPUEstimator(
+        estimator_classifier = tf.contrib.tpu.TPUEstimator(
                                     use_tpu=True,
                                     model_fn=estimator_fn,
                                     config=m_config,

--- a/tfutils/tpu_train.py
+++ b/tfutils/tpu_train.py
@@ -31,7 +31,7 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
     validation_params = param['validation_params']
     save_params = param['save_params']
     # set up estimator func
-    estimator_fn, params_to_pass = create_train_estimator_fn(use_tpu=use_tpu, 
+    estimator_fn, params_to_pass = create_train_estimator_fn(use_tpu=use_tpu,
                                        model_params=model_params,
                                        lr_params=lr_params,
                                        opt_params=opt_params,
@@ -47,22 +47,23 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
             eval_batch_size = None
         # grab tpu name and gcp, etc from model params
         m_config = create_train_tpu_config(model_dir=save_params.get('cache_dir', ''),
-                                     tpu_name=model_params.get('tpu_name', None), 
-                                     gcp_project=model_params.get('gcp_project', None), 
+                                     tpu_name=model_params.get('tpu_name', None),
+                                     gcp_project=model_params.get('gcp_project', None),
                                      steps_per_checkpoint=save_params.get('save_filters_freq', None),
-                                     tpu_zone=model_params.get('tpu_zone', DEFAULT_TPU_ZONE), 
+                                     tpu_zone=model_params.get('tpu_zone', DEFAULT_TPU_ZONE),
                                      num_shards=model_params.get('num_shards', DEFAULT_NUM_SHARDS),
                                      keep_checkpoint_max=save_params.get('checkpoint_max', 5),
                                      iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
                                      model_params=model_params)
 
-        estimator_classifier = tpu_estimator.TPUEstimator(
+        estimator_classifier = tf.estimator.tpu.TPUEstimator(
                                     use_tpu=True,
                                     model_fn=estimator_fn,
                                     config=m_config,
                                     train_batch_size=train_data_params['batch_size'],
                                     eval_batch_size=eval_batch_size,
-                                    params=params_to_pass)
+                                    params=params_to_pass,
+                                    export_to_tpu=False)
 
     else:
         estimator_classifier = tf.estimator.Estimator(model_fn=estimator_fn, params=params_to_pass)

--- a/tfutils/tpu_train.py
+++ b/tfutils/tpu_train.py
@@ -76,7 +76,7 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
                                 keep_checkpoint_max=save_params.get('checkpoint_max', 5),
                                 iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
                                 model_params=model_params)
-            if model_params.get('num_shards', DEFAULT_NUM_SHARDS) > 8:
+
             val_estimator_classifier = tf.contrib.tpu.TPUEstimator(
                                         use_tpu=True,
                                         model_fn=estimator_fn,
@@ -86,11 +86,9 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
                                         params=params_to_pass,
                                         export_to_tpu=False)
 
-
-
-
     else:
-        train_estimator_classifier = tf.estimator.Estimator(model_fn=estimator_fn, params=params_to_pass)
+        train_estimator_classifier = tf.estimator.Estimator(model_fn=estimator_fn,
+                                                            params=params_to_pass)
 
     return train_estimator(train_cls=train_estimator_classifier,
                            eval_cls=val_estimator_classifier,

--- a/tfutils/tpu_train.py
+++ b/tfutils/tpu_train.py
@@ -46,26 +46,53 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
         else:
             eval_batch_size = None
         # grab tpu name and gcp, etc from model params
-        m_config = create_train_tpu_config(model_dir=save_params.get('cache_dir', ''),
-                                     tpu_name=model_params.get('tpu_name', None),
-                                     gcp_project=model_params.get('gcp_project', None),
-                                     steps_per_checkpoint=save_params.get('save_filters_freq', None),
-                                     tpu_zone=model_params.get('tpu_zone', DEFAULT_TPU_ZONE),
-                                     num_shards=model_params.get('num_shards', DEFAULT_NUM_SHARDS),
-                                     keep_checkpoint_max=save_params.get('checkpoint_max', 5),
-                                     iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
-                                     model_params=model_params)
-
-        estimator_classifier = tf.contrib.tpu.TPUEstimator(
+        train_m_config = create_train_tpu_config(model_dir=save_params.get('cache_dir', ''),
+                            tpu_name=model_params.get('tpu_name', None),
+                            gcp_project=model_params.get('gcp_project', None),
+                            steps_per_checkpoint=save_params.get('save_filters_freq', None),
+                            tpu_zone=model_params.get('tpu_zone', DEFAULT_TPU_ZONE),
+                            num_shards=model_params.get('num_shards', DEFAULT_NUM_SHARDS),
+                            keep_checkpoint_max=save_params.get('checkpoint_max', 5),
+                            iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
+                            model_params=model_params)
+        train_estimator_classifier = tf.contrib.tpu.TPUEstimator(
                                     use_tpu=True,
                                     model_fn=estimator_fn,
-                                    config=m_config,
+                                    config=train_m_config,
                                     train_batch_size=train_data_params['batch_size'],
                                     eval_batch_size=eval_batch_size,
                                     params=params_to_pass,
                                     export_to_tpu=False)
+        val_estimator_classifier = None
+
+        if model_params.get('num_shards', DEFAULT_NUM_SHARDS) > 8:
+            print("You are running in pod mode")
+            val_m_config = create_train_tpu_config(model_dir=save_params.get('cache_dir', ''),
+                                tpu_name=model_params.get('val_tpu_name', None),
+                                gcp_project=model_params.get('gcp_project', None),
+                                steps_per_checkpoint=save_params.get('save_filters_freq', None),
+                                tpu_zone=model_params.get('val_tpu_zone', DEFAULT_TPU_ZONE),
+                                num_shards=8,
+                                keep_checkpoint_max=save_params.get('checkpoint_max', 5),
+                                iterations_per_loop=model_params.get('iterations_per_loop', DEFAULT_ITERATIONS_PER_LOOP),
+                                model_params=model_params)
+            if model_params.get('num_shards', DEFAULT_NUM_SHARDS) > 8:
+            val_estimator_classifier = tf.contrib.tpu.TPUEstimator(
+                                        use_tpu=True,
+                                        model_fn=estimator_fn,
+                                        config=val_m_config,
+                                        train_batch_size=train_data_params['batch_size'],
+                                        eval_batch_size=eval_batch_size,
+                                        params=params_to_pass,
+                                        export_to_tpu=False)
+
+
+
 
     else:
-        estimator_classifier = tf.estimator.Estimator(model_fn=estimator_fn, params=params_to_pass)
+        train_estimator_classifier = tf.estimator.Estimator(model_fn=estimator_fn, params=params_to_pass)
 
-    return train_estimator(cls=estimator_classifier, param=param, trarg=trarg)
+    return train_estimator(train_cls=train_estimator_classifier,
+                           eval_cls=val_estimator_classifier,
+                           param=param,
+                           trarg=trarg)


### PR DESCRIPTION
Now you can specify a tpu pod or slice in `tpu_name`, but will require an additional single device `eval_tpu_name` to be specified to perform evaluation on, as eval is currently unsupported on pods. 

Also accounts for different locations of the objects required for TPUTraining:
* TPUEstimatorSpec
* TPUEstimator
* RunConfig
* TPUConfig
* CrossShardOptimizer
* TPUClusterResolver