### PR TITLE
[TPU] Python 3 compatibility  + `metric_fn` eval code rewrite

### DIFF
--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -39,7 +39,7 @@ def train_estimator(train_cls,
     need_val = len(param['validation_params'].keys())>0
     steps_per_eval = param['save_params'].get('save_valid_freq')
     if need_val:
-        valid_k = param['validation_params'].keys()[0]
+        valid_k = list(param['validation_params'].keys())[0]
         validation_data_params = param['validation_params'][valid_k]['data_params']
         valid_steps = param['validation_params'][valid_k]['num_steps']
         valid_fn = validation_data_params['func']
@@ -256,7 +256,7 @@ def create_train_estimator_fn(use_tpu,
             metric_fn_kwargs = {'labels': labels, 'logits': logits}
             if use_tpu:
                 assert(num_valid_targets==1) # tpu estimators currently only support single targets :(
-                first_valid = validation_params.keys()[0]
+                first_valid = list(validation_params.keys())[0]
                 valid_target = validation_params[first_valid]['targets']
                 metric_fn = valid_target['func']
                 if isinstance(outputs, dict):

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -68,7 +68,8 @@ def train_estimator(train_cls,
     else:
         valid_hooks = None
 
-    current_step = estimator._load_global_step_from_checkpoint_dir(model_dir)
+    # must cast to int because this function can return np.int64 on some versions of TF, and the estimator API expects int (and not np.int64) to be passed to max_steps
+    current_step = int(estimator._load_global_step_from_checkpoint_dir(model_dir))
     # initialize db here (currently no support for loading and saving to different places. May need to modify init so load_params can load from different dir, estimator interface limited
     #    when loading and saving to different paths, may need to create a new config)
 

--- a/tfutils/tpu_helper.py
+++ b/tfutils/tpu_helper.py
@@ -297,9 +297,9 @@ def create_train_estimator_fn(use_tpu,
                     metric_fn = validation_target.pop("func")
 
                     # merge the default metric fn kwargs (with labels and logits) with the target-specific kwargs
-                    metric_fn_kwargs.update(validation_target)
+                    validation_metric_fn_kwargs = {**metric_fn_kwargs, **validation_target}
 
-                    eval_dict[validation] = (metric_fn, metric_fn_kwargs)
+                    eval_dict[validation] = (metric_fn, validation_metric_fn_kwargs)
                 eval_metrics = eval_dict
 
         # choose estimator based on use_tpu flag

--- a/tfutils/tpu_train.py
+++ b/tfutils/tpu_train.py
@@ -51,7 +51,7 @@ def tpu_train_from_params(params, train_args, use_tpu=False):
 
     if use_tpu:
         if len(param['validation_params'].keys())>0:
-            valid_k = param['validation_params'].keys()[0]
+            valid_k = list(param['validation_params'].keys())[0]
             validation_data_params = param['validation_params'][valid_k]['data_params']
             eval_batch_size = validation_data_params['batch_size']
         else:


### PR DESCRIPTION
### Python 3 Conversion
I encountered a few stray bugs while using the tpu-specific utilities with Python 3. Specifically I'm using 3.7.10 but these problems should affect all Python 3.x. They're mostly fixed by casting things to better datatypes.

### Metric Fn Madness
I'm also simplifying and better-documenting the code that deals with the `metric_fn`, since both @anayebi and I had forgotten the specifics of how it works.

I want to explain here why it's such a sticky issue w/ TPUs:
When training, we're able to pass arbitrary `args` and `kwargs` to the loss function, so a signature like this is fairly common:
```python
def loss_per_case(outputs, labels, **kwargs):
    loss = category_loss(outputs["logits"], labels)
```
We're able to pass the model_fn outputs in whatever form they may be (often a dictionary, at least in my use cases):
https://github.com/neuroailab/tfutils/blob/830a50eb79f6a9398caa75c9fd2d58a6cadd826d/tfutils/tpu_helper.py#L212-L221

However, the `metric_fn` run during eval mode only accepts arguments that are tensors or a dictionary of tensors. Here's the description from [the docs](https://www.tensorflow.org/api_docs/python/tf/compat/v1/estimator/tpu/TPUEstimatorSpec): 
>While EstimatorSpec.eval_metric_ops expects a dict, TPUEstimatorSpec.eval_metrics is a tuple of metric_fn and tensors. The tensors could be a list of Tensors or dict of names to Tensors. The tensors usually specify the model logits, which are transferred back from TPU system to CPU host. All tensors must have be batch-major, i.e., the batch size is the first dimension.

Here's our fix -- if `outputs` is a dictionary, spread its key-tensor pairs to the metric fn:
https://github.com/neuroailab/tfutils/blob/26002b31ebfb1cd40bac54a23b8cddabcf25c567/tfutils/tpu_helper.py#L282-L288

We also allow arbitrary kwargs to be passed in the "targets" dict, but again, they must be tensors:
https://github.com/neuroailab/tfutils/blob/26002b31ebfb1cd40bac54a23b8cddabcf25c567/tfutils/tpu_helper.py#L278-L279
Note that `all([]) == True` so if there are no args other than "func", this code has no effect (it will update with the empty dict {}) which does nothing. 

#### Breaking changes
The previous version of this code permitted a hacky workaround: if one of the values in `outputs` was a dictionary, its key-value pairs were spread into the metric_fn call, effectively flattening the dictionary before using its key-value pairs in the call to metric_fn. I'm removing that corner case to simplify the API and prevent confusion. Users can instead write simple `metric_fn`s that accept tensors as input.